### PR TITLE
fix: Remove postinstall script and vercel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "postinstall": "vercel dev"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -18,7 +17,6 @@
     "@types/node": "^22.14.0",
     "typescript": "~5.7.2",
     "vite": "^6.2.0",
-    "vercel": "^32.3.0",
     "@vercel/node": "^3.0.0"
   }
 }


### PR DESCRIPTION
The `postinstall` script was causing the Vercel build to fail because it was trying to run `vercel dev`, which requires authentication. This command is only needed for local development.

The `vercel` CLI dependency is also not needed in the deployed application, so it has been removed.